### PR TITLE
Add optional duration parameter to setBrightness

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,22 @@ api.getBrightness()
   });
 ```
 
-### Set the brightness value ###
+### Set the brightness value immediately ###
 
 ```javascript
 api.setBrightness(50)
+  .then(function() {
+    console.log('Success!');
+  })
+  .catch(function(err) {
+    console.error(err);
+  });
+```
+
+### Set the brightness value with a duration of 5 seconds ###
+
+```javascript
+api.setBrightness(50, 5)
   .then(function() {
     console.log('Success!');
   })
@@ -240,6 +252,9 @@ api.identify()
 ```
 
 ## Changelog ##
+
+### 1.2.3 (2018.10.09)
+- (J. Hillert) Added optional duration when setting brightness.
 
 ### 1.2.2 (2018.01.18)
 - (Xyala) Added script to get token.

--- a/index.js
+++ b/index.js
@@ -188,9 +188,12 @@ AuroraApi.prototype.getBrightness = function () {
   return this.doRequest(requestOptions);
 };
 
-AuroraApi.prototype.setBrightness = function (value) {
+AuroraApi.prototype.setBrightness = function (value, duration = 0) {
   const requestOptions = this.makePutRequest('/state', {
-    brightness: value
+    brightness: {
+      value: value,
+      duration: duration
+    }
   });
 
   return this.doRequest(requestOptions);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoleaf-aurora-client",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "dependencies": {
     "ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoleaf-aurora-client",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": "Darren Thomas <darren.thomas@me.com>",
   "description": "Nanoleaf Aurora API client",
   "main": "index.js",

--- a/test.js
+++ b/test.js
@@ -126,7 +126,7 @@ describe('Aurora Api tests:', () => {
           .put(`${options.base}${options.accessToken}/state`, {
             on: {
               value: true
-            }  
+            }
           })
           .reply(500);
 
@@ -154,7 +154,7 @@ describe('Aurora Api tests:', () => {
           .put(`${options.base}${options.accessToken}/state`, {
             on: {
               value: false
-            }  
+            }
           })
           .reply(500);
 
@@ -192,22 +192,24 @@ describe('Aurora Api tests:', () => {
       it('should request', () => {
         const request = nock(`http://${options.host}:${options.port}`)
           .put(`${options.base}${options.accessToken}/state`, {
-            'brightness': 100
+            'brightness': 100,
+            'duration': 1
           })
           .reply(200);
 
-        api.setBrightness(100).should.be.fulfilled();
+        api.setBrightness(100, 1).should.be.fulfilled();
         request.done();
       });
 
       it('should reject when request fails', () => {
         const request = nock(`http://${options.host}:${options.port}`)
           .put(`${options.base}${options.accessToken}/state`, {
-            'brightness': 100
+            'brightness': 100,
+            'duration': 1
           })
           .reply(500);
 
-        api.setBrightness(100).should.be.rejected();
+        api.setBrightness(100, 1).should.be.rejected();
         request.done();
       });
     });


### PR DESCRIPTION
Hi,

In the Nanoleaf documentation I found a passage that allows to add a duration when setting the brightness to a certain level.

Endpoint | /api/v1/<auth_token>/state
-- | --
Request | PUT
Request Body | {"brightness" : {"value":100, "duration":30}}OR{"brightness" : {"increment":-10}}Duration field is optional, and specified in seconds

I tried to include that in the code, but I am no JS expert.
**I don't know if the syntax is correct and I don't know how to test the code.**

Could you do me the favor to review and test my changes. I hope they are worth to be included in the software. May be you know a much better way to include the changes. I would really appreciate your feedback.

Thank you very much.

J. Hillert.